### PR TITLE
add Windows code signing config to prevent antivirus false positives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Build executables
         run: npm run package
         timeout-minutes: 20
+        env:
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Windows code signing configuration to prevent antivirus false positives
+
 ## [0.0.2] - 2025-08-03
 
 ### Added

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -36,7 +36,12 @@
         "arch": ["x64"]
       }
     ],
-    "icon": "assets/icons/VibeTree.png"
+    "icon": "assets/icons/VibeTree.png",
+    "certificateSubjectName": null,
+    "certificateSha1": null,
+    "signingHashAlgorithms": ["sha256"],
+    "rfc3161TimeStampServer": "http://timestamp.digicert.com",
+    "signDlls": true
   },
   "nsis": {
     "oneClick": false,


### PR DESCRIPTION
- Configure electron-builder with Windows signing options
- Add GitHub Actions environment variables for certificate handling
- Enable SHA256 signing with DigiCert timestamp server
- Sign all DLLs to ensure complete coverage

Fixes #12

## Setup Required:

To complete the code signing setup, the following steps are needed:

1. [ ] Obtain a code signing certificate from a trusted Certificate Authority:
   - Option A: Azure Trusted Signing (recommended for US/Canada organizations)
   - Option B: Extended Validation (EV) certificate for immediate trust
   - Option C: Organization Validation (OV) certificate (builds trust over time)

2. [ ] Convert certificate to base64 format: ```bash # For .pfx or .p12 files base64 -i certificate.pfx -o certificate_base64.txt ```

3. [ ] Add GitHub repository secrets:
   - Go to Settings → Secrets and variables → Actions
   - Add WIN_CSC_LINK (base64-encoded certificate content)
   - Add WIN_CSC_KEY_PASSWORD (certificate password)

4. [ ] Create a new release to test the signed build

Once configured, Windows Defender should no longer flag VibeTree as malware.