### PR TITLE
feat: open terminal links in default browser instead of in-app browser

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, nativeTheme, dialog } from 'electron';
+import { app, BrowserWindow, ipcMain, nativeTheme, dialog, shell } from 'electron';
 import path from 'path';
 import { shellProcessManager } from './shell-manager';
 import './ide-detector';
@@ -105,6 +105,11 @@ ipcMain.handle('dialog:select-directory', async () => {
     properties: ['openDirectory']
   });
   return result.filePaths[0];
+});
+
+// Open external links
+ipcMain.handle('shell:open-external', async (_, url: string) => {
+  await shell.openExternal(url);
 });
 
 // Parsing functions are now imported from @vibetree/core

--- a/apps/desktop/src/main/shell-manager.ts
+++ b/apps/desktop/src/main/shell-manager.ts
@@ -52,7 +52,7 @@ class DesktopShellManager {
       return { running: this.sessionManager.hasSession(processId) };
     });
 
-    ipcMain.handle('shell:get-buffer', async (_, processId: string) => {
+    ipcMain.handle('shell:get-buffer', async (_) => {
       // Buffer management handled on renderer side
       return { success: true, buffer: null };
     });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -26,6 +26,8 @@ const api = {
       ipcRenderer.invoke('shell:status', processId),
     getBuffer: (processId: string) => 
       ipcRenderer.invoke('shell:get-buffer', processId),
+    openExternal: (url: string) =>
+      ipcRenderer.invoke('shell:open-external', url),
     onOutput: (processId: string, callback: (data: string) => void) => {
       const channel = `shell:output:${processId}`;
       const listener = (_: unknown, data: string) => callback(data);

--- a/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
+++ b/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
@@ -108,7 +108,11 @@ export function ClaudeTerminal({ worktreePath, theme = 'dark' }: ClaudeTerminalP
     fitAddonRef.current = fitAddon;
     term.loadAddon(fitAddon);
     
-    const webLinksAddon = new WebLinksAddon();
+    // Configure WebLinksAddon with custom handler for opening links
+    const webLinksAddon = new WebLinksAddon((event, uri) => {
+      // Open in default browser using Electron's shell.openExternal
+      window.electronAPI.shell.openExternal(uri);
+    });
     term.loadAddon(webLinksAddon);
     
     const serializeAddon = new SerializeAddon();

--- a/packages/ui/src/components/Terminal.tsx
+++ b/packages/ui/src/components/Terminal.tsx
@@ -162,7 +162,17 @@ export const Terminal: React.FC<TerminalProps> = ({
     fitAddonRef.current = fitAddon;
     term.loadAddon(fitAddon);
     
-    const webLinksAddon = new WebLinksAddon();
+    // Configure WebLinksAddon with custom handler for opening links
+    const webLinksAddon = new WebLinksAddon((event, uri) => {
+      // Check if we're in Electron environment
+      if (window.electronAPI && window.electronAPI.shell && window.electronAPI.shell.openExternal) {
+        // Open in default browser using Electron's shell.openExternal
+        window.electronAPI.shell.openExternal(uri);
+      } else {
+        // Fallback to opening in new tab for web environment
+        window.open(uri, '_blank');
+      }
+    });
     term.loadAddon(webLinksAddon);
     
     const serializeAddon = new SerializeAddon();

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -1,0 +1,13 @@
+interface ElectronAPI {
+  shell?: {
+    openExternal?: (url: string) => Promise<void>;
+  };
+}
+
+declare global {
+  interface Window {
+    electronAPI?: ElectronAPI;
+  }
+}
+
+export {};


### PR DESCRIPTION
- Added IPC handler for shell.openExternal in main process
- Exposed openExternal method through preload script
- Updated Terminal and ClaudeTerminal components with custom WebLinksAddon handler
- Added TypeScript definitions for electronAPI
- Fixed unused parameter warning in shell-manager

This change ensures that when users click on links in the terminal, they open in the system's default browser (Chrome, Safari, Firefox, etc.) rather than an embedded webview.

🤖 Generated with [Claude Code](https://claude.ai/code)