### PR TITLE
feat: Launch file dialog directly when clicking plus button

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -10,7 +10,6 @@ import { Plus, X } from 'lucide-react';
 
 function AppContent() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
-  const [showProjectSelector, setShowProjectSelector] = useState(false);
   const { projects, activeProjectId, addProject, removeProject, setActiveProject } = useProjects();
 
   useEffect(() => {
@@ -50,7 +49,13 @@ function AppContent() {
 
   const handleSelectProject = (path: string) => {
     addProject(path);
-    setShowProjectSelector(false);
+  };
+
+  const handleOpenProjectDialog = async () => {
+    const path = await window.electronAPI.dialog.selectDirectory();
+    if (path) {
+      addProject(path);
+    }
   };
 
   const handleCloseProject = (e: React.MouseEvent, projectId: string) => {
@@ -68,7 +73,7 @@ function AppContent() {
     <div className="h-screen flex flex-col bg-background">
       <AppHeader theme={theme} onThemeToggle={toggleTheme} />
 
-      {projects.length === 0 || showProjectSelector ? (
+      {projects.length === 0 ? (
         <ProjectSelector onSelectProject={handleSelectProject} />
       ) : (
         <Tabs 
@@ -97,7 +102,7 @@ function AppContent() {
             <Button
               size="icon"
               variant="ghost"
-              onClick={() => setShowProjectSelector(true)}
+              onClick={handleOpenProjectDialog}
               className="h-8 w-8"
             >
               <Plus className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Removed intermediate ProjectSelector page when adding new projects
- Plus button now directly opens the native file dialog
- Simplified user experience with fewer clicks required

## Changes
- Modified `App.tsx` to add `handleOpenProjectDialog` function that directly calls the file dialog API
- Removed `showProjectSelector` state variable that was used to show the intermediate page
- Updated plus button onClick handler to use the new direct dialog approach
- Cleaned up rendering logic to only show ProjectSelector when no projects exist

## Test Plan
- [x] Click the plus button - should directly open file dialog
- [x] Select a project folder - should add the project
- [x] Cancel the dialog (press Escape or close) - should cancel the operation without showing any intermediate page
- [x] Verify typecheck passes

🤖 Generated with [Claude Code](https://claude.ai/code)