### PR TITLE
fix: Launch terminal shells as login shells to match iTerm2 PATH

### DIFF
--- a/packages/core/src/services/ShellSessionManager.ts
+++ b/packages/core/src/services/ShellSessionManager.ts
@@ -104,7 +104,10 @@ export class ShellSessionManager {
 
       const shell = getDefaultShell();
       const options = getPtyOptions(worktreePath, cols, rows);
-      const ptyProcess = spawnFunction(shell, [], options);
+      // Launch as login shell to ensure proper PATH initialization
+      // For zsh/bash, use -l flag. For other shells, keep empty args
+      const shellArgs = shell.includes('zsh') || shell.includes('bash') ? ['-l'] : [];
+      const ptyProcess = spawnFunction(shell, shellArgs, options);
 
       const session: ShellSession = {
         id: sessionId,


### PR DESCRIPTION
## Summary
- Fixes PATH inconsistency between the terminal app and iTerm2
- Launches shells with `-l` flag to ensure proper login shell initialization
- Ensures all system and user paths are properly loaded

## Problem
The terminal app was launching shells without proper initialization, resulting in a different PATH compared to iTerm2. Missing paths included:
- `/usr/local/bin`
- `/System/Cryptexes/App/usr/bin`
- Various system and application paths

## Solution
Modified `ShellSessionManager.ts` to launch zsh/bash shells with the `-l` flag, making them login shells that properly source all initialization files (including `/etc/paths`, `/etc/paths.d/*`, and user profile files).

## Test plan
- [x] Launch terminal in the app
- [x] Run `echo $PATH` and verify it matches iTerm2's PATH
- [x] Confirm all expected paths are present
- [x] Test that existing functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)