### PR TITLE
fix: add missing external dependencies in build scripts

### DIFF
--- a/packages/auth/build.js
+++ b/packages/auth/build.js
@@ -14,7 +14,7 @@ await build({
   format: 'esm',
   platform: 'browser',
   target: 'es2020',
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'clsx'],
   sourcemap: true,
 });
 
@@ -27,7 +27,7 @@ await build({
   format: 'cjs',
   platform: 'browser',
   target: 'es2020',
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'clsx'],
   sourcemap: true,
 });
 

--- a/packages/ui/build.js
+++ b/packages/ui/build.js
@@ -14,7 +14,7 @@ await build({
   format: 'esm',
   platform: 'browser',
   target: 'es2020',
-  external: ['react', 'react-dom', '@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-serialize', '@xterm/addon-unicode11', '@xterm/addon-web-links', 'clsx'],
+  external: ['react', 'react-dom', '@vibetree/core', '@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-search', '@xterm/addon-serialize', '@xterm/addon-unicode11', '@xterm/addon-web-links', 'clsx'],
   sourcemap: true,
 });
 
@@ -27,7 +27,7 @@ await build({
   format: 'cjs',
   platform: 'browser',
   target: 'es2020',
-  external: ['react', 'react-dom', '@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-serialize', '@xterm/addon-unicode11', '@xterm/addon-web-links', 'clsx'],
+  external: ['react', 'react-dom', '@vibetree/core', '@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-search', '@xterm/addon-serialize', '@xterm/addon-unicode11', '@xterm/addon-web-links', 'clsx'],
   sourcemap: true,
 });
 


### PR DESCRIPTION
- Add @vibetree/core and @xterm/addon-search to UI package externals
- Add clsx to Auth package externals
- Fixes pnpm Plug'n'Play dependency resolution errors during build

Resolves build failures where esbuild couldn't resolve workspace dependencies and external packages that should not be bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)