### PR TITLE
Sort worktrees alphabetically with main branch first

### DIFF
--- a/apps/desktop/src/renderer/components/WorktreePanel.tsx
+++ b/apps/desktop/src/renderer/components/WorktreePanel.tsx
@@ -322,7 +322,23 @@ export function WorktreePanel({ projectPath, selectedWorktree, onSelectWorktree,
 
       <ScrollArea className="flex-1 h-0">
         <div className="p-2">
-          {worktrees.map((worktree) => (
+          {[...worktrees].sort((a, b) => {
+            // Extract branch names, handling refs/heads/ prefix and detached HEAD
+            const getBranchName = (wt: Worktree) => {
+              if (!wt.branch) return wt.head.substring(0, 8); // detached HEAD
+              return wt.branch.replace('refs/heads/', '');
+            };
+
+            const branchA = getBranchName(a);
+            const branchB = getBranchName(b);
+
+            // Keep main or master first
+            if (branchA === 'main' || branchA === 'master') return -1;
+            if (branchB === 'main' || branchB === 'master') return 1;
+
+            // Sort alphabetically for the rest
+            return branchA.localeCompare(branchB);
+          }).map((worktree) => (
             <div
               key={worktree.path}
               className={`relative group rounded-md transition-colors ${

--- a/apps/web/src/components/WorktreePanel.tsx
+++ b/apps/web/src/components/WorktreePanel.tsx
@@ -176,7 +176,23 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
           </div>
         ) : (
           <div className="p-2">
-            {project.worktrees.map((worktree) => {
+            {[...project.worktrees].sort((a, b) => {
+              // Extract branch names, handling refs/heads/ prefix and detached HEAD
+              const getBranchName = (wt: typeof a) => {
+                if (!wt.branch) return wt.head.substring(0, 8); // detached HEAD
+                return wt.branch.replace('refs/heads/', '');
+              };
+
+              const branchA = getBranchName(a);
+              const branchB = getBranchName(b);
+
+              // Keep main or master first
+              if (branchA === 'main' || branchA === 'master') return -1;
+              if (branchB === 'main' || branchB === 'master') return 1;
+
+              // Sort alphabetically for the rest
+              return branchA.localeCompare(branchB);
+            }).map((worktree) => {
               console.log('🌳 Rendering worktree:', { 
                 branch: worktree.branch, 
                 path: worktree.path,


### PR DESCRIPTION
## Summary

This PR enhances the worktree display by implementing alphabetical sorting while keeping the main/master branch at the top:

- Worktrees are now sorted alphabetically by branch name for easier navigation
- Main and master branches are always pinned to the top of the list
- Detached HEAD states are handled gracefully (sorted by commit hash)
- Applied consistently to both desktop and web WorktreePanel components
- Existing ScrollArea components already provide proper scrolling behavior for many worktrees

## Test plan

- [ ] Verify worktrees display in alphabetical order (case-insensitive)
- [ ] Confirm main/master branch appears first in the list
- [ ] Test with multiple worktrees to ensure sorting is correct
- [ ] Verify detached HEAD worktrees display correctly
- [ ] Confirm scrolling works properly when many worktrees are present
- [ ] Test in both desktop and web applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)