### PR TITLE
fix: Make worktree list scrollable within app height

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -77,10 +77,10 @@ function AppContent() {
       {projects.length === 0 ? (
         <ProjectSelector onSelectProject={handleSelectProject} />
       ) : (
-        <Tabs 
-          value={activeProjectId || ''} 
+        <Tabs
+          value={activeProjectId || ''}
           onValueChange={setActiveProject}
-          className="flex-1 flex flex-col"
+          className="flex-1 flex flex-col overflow-hidden"
         >
           <div className="border-b flex items-center gap-2 bg-muted/50 h-10">
             <TabsList className="h-full bg-transparent p-0 rounded-none">
@@ -111,10 +111,10 @@ function AppContent() {
           </div>
 
           {projects.map((project) => (
-            <TabsContent 
-              key={project.id} 
+            <TabsContent
+              key={project.id}
               value={project.id}
-              className="flex-1 m-0 h-full"
+              className="flex-1 m-0 h-0 overflow-hidden"
             >
               <ProjectWorkspace projectId={project.id} theme={theme} />
             </TabsContent>

--- a/apps/desktop/src/renderer/components/ProjectWorkspace.tsx
+++ b/apps/desktop/src/renderer/components/ProjectWorkspace.tsx
@@ -16,7 +16,7 @@ export function ProjectWorkspace({ projectId, theme }: ProjectWorkspaceProps) {
   }
 
   return (
-    <div className="flex-1 flex h-full">
+    <div className="flex h-full overflow-hidden">
       <WorktreePanel
         projectPath={project.path}
         selectedWorktree={project.selectedWorktree}
@@ -25,8 +25,8 @@ export function ProjectWorkspace({ projectId, theme }: ProjectWorkspaceProps) {
         initialWorktrees={project.worktrees}
       />
       {project.selectedWorktree && (
-        <RightPaneView 
-          worktreePath={project.selectedWorktree} 
+        <RightPaneView
+          worktreePath={project.selectedWorktree}
           projectId={projectId}
           theme={theme}
         />


### PR DESCRIPTION
## Summary
- Fixed worktree list overflow by properly constraining ScrollArea height
- Updated flex container hierarchy to enable scrolling through 200+ worktrees
- Terminal sizing remains unaffected

## Changes
- **App.tsx**: Added `overflow-hidden` to Tabs, changed TabsContent from `h-full` to `h-0 overflow-hidden`
- **ProjectWorkspace.tsx**: Removed `flex-1`, added `overflow-hidden`

## Test plan
- [x] Created 200 worktrees in test repository
- [x] Verified worktree list scrolls through all items
- [x] Confirmed list stays within app window bounds
- [x] Verified terminal size is not affected
- [x] Tested scrolling to bottom (stress-200) and top (main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)