### PR TITLE
Design pass: compact, aligned, monochrome UI

### DIFF
--- a/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
+++ b/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
@@ -463,10 +463,10 @@ export function ClaudeTerminal({
         };
       } else {
         return {
-          background: '#000000',
-          foreground: '#ffffff',
+          background: '#101312',
+          foreground: '#e6ebe9',
           cursor: '#ffffff',
-          cursorAccent: '#000000',
+          cursorAccent: '#101312',
           selectionBackground: '#4a4a4a',
           black: '#000000',
           red: '#cd3131',
@@ -877,10 +877,10 @@ export function ClaudeTerminal({
         };
       } else {
         return {
-          background: '#000000',
-          foreground: '#ffffff',
+          background: '#101312',
+          foreground: '#e6ebe9',
           cursor: '#ffffff',
-          cursorAccent: '#000000',
+          cursorAccent: '#101312',
           selectionBackground: '#4a4a4a'
         };
       }
@@ -1195,7 +1195,7 @@ export function ClaudeTerminal({
       {/* Terminal container */}
       <div
         ref={terminalRef}
-        className={`terminal-xterm-container flex-1 h-full ${theme === 'light' ? 'bg-white' : 'bg-black'}`}
+        className="terminal-xterm-container flex-1 h-full bg-background"
         onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
+++ b/apps/desktop/src/renderer/components/ClaudeTerminal.tsx
@@ -463,10 +463,10 @@ export function ClaudeTerminal({
         };
       } else {
         return {
-          background: '#101312',
-          foreground: '#e6ebe9',
+          background: '#000000',
+          foreground: '#ffffff',
           cursor: '#ffffff',
-          cursorAccent: '#101312',
+          cursorAccent: '#000000',
           selectionBackground: '#4a4a4a',
           black: '#000000',
           red: '#cd3131',
@@ -877,10 +877,10 @@ export function ClaudeTerminal({
         };
       } else {
         return {
-          background: '#101312',
-          foreground: '#e6ebe9',
+          background: '#000000',
+          foreground: '#ffffff',
           cursor: '#ffffff',
-          cursorAccent: '#101312',
+          cursorAccent: '#000000',
           selectionBackground: '#4a4a4a'
         };
       }

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -3,49 +3,51 @@
 @tailwind utilities;
 
 @layer base {
+  /* Shared VibeTree palette: green-cast neutrals with one emerald accent,
+     kept identical to the web app so both clients read as one product */
   :root {
     --background: 0 0% 100%;
-    --foreground: 0 0% 0%;
+    --foreground: 168 15% 12%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 0%;
+    --card-foreground: 168 15% 12%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 0%;
-    --primary: 0 0% 0%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 0 0% 96%;
-    --secondary-foreground: 0 0% 0%;
-    --muted: 0 0% 96%;
-    --muted-foreground: 0 0% 40%;
-    --accent: 0 0% 96%;
-    --accent-foreground: 0 0% 0%;
-    --destructive: 0 0% 0%;
+    --popover-foreground: 168 15% 12%;
+    --primary: 156 65% 30%;
+    --primary-foreground: 150 40% 98%;
+    --secondary: 150 12% 96%;
+    --secondary-foreground: 168 15% 15%;
+    --muted: 150 12% 96%;
+    --muted-foreground: 160 6% 42%;
+    --accent: 150 12% 94%;
+    --accent-foreground: 168 15% 12%;
+    --destructive: 0 74% 48%;
     --destructive-foreground: 0 0% 100%;
-    --border: 0 0% 90%;
-    --input: 0 0% 90%;
-    --ring: 0 0% 0%;
+    --border: 155 10% 89%;
+    --input: 155 10% 85%;
+    --ring: 156 65% 30%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 0 0% 0%;
-    --foreground: 0 0% 100%;
-    --card: 0 0% 0%;
-    --card-foreground: 0 0% 100%;
-    --popover: 0 0% 0%;
-    --popover-foreground: 0 0% 100%;
-    --primary: 0 0% 100%;
-    --primary-foreground: 0 0% 0%;
-    --secondary: 0 0% 10%;
-    --secondary-foreground: 0 0% 100%;
-    --muted: 0 0% 10%;
-    --muted-foreground: 0 0% 60%;
-    --accent: 0 0% 10%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 0% 100%;
-    --destructive-foreground: 0 0% 0%;
-    --border: 0 0% 15%;
-    --input: 0 0% 15%;
-    --ring: 0 0% 100%;
+    --background: 165 8% 7%;
+    --foreground: 150 10% 92%;
+    --card: 165 8% 9%;
+    --card-foreground: 150 10% 92%;
+    --popover: 165 8% 9%;
+    --popover-foreground: 150 10% 92%;
+    --primary: 152 55% 52%;
+    --primary-foreground: 165 30% 8%;
+    --secondary: 165 7% 12%;
+    --secondary-foreground: 150 10% 92%;
+    --muted: 165 7% 12%;
+    --muted-foreground: 155 6% 58%;
+    --accent: 165 7% 15%;
+    --accent-foreground: 150 10% 92%;
+    --destructive: 0 62% 52%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 165 6% 16%;
+    --input: 165 6% 20%;
+    --ring: 152 55% 52%;
   }
 }
 

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -3,51 +3,49 @@
 @tailwind utilities;
 
 @layer base {
-  /* Shared VibeTree palette: green-cast neutrals with one emerald accent,
-     kept identical to the web app so both clients read as one product */
   :root {
     --background: 0 0% 100%;
-    --foreground: 168 15% 12%;
+    --foreground: 0 0% 0%;
     --card: 0 0% 100%;
-    --card-foreground: 168 15% 12%;
+    --card-foreground: 0 0% 0%;
     --popover: 0 0% 100%;
-    --popover-foreground: 168 15% 12%;
-    --primary: 156 65% 30%;
-    --primary-foreground: 150 40% 98%;
-    --secondary: 150 12% 96%;
-    --secondary-foreground: 168 15% 15%;
-    --muted: 150 12% 96%;
-    --muted-foreground: 160 6% 42%;
-    --accent: 150 12% 94%;
-    --accent-foreground: 168 15% 12%;
-    --destructive: 0 74% 48%;
+    --popover-foreground: 0 0% 0%;
+    --primary: 0 0% 0%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 40%;
+    --accent: 0 0% 96%;
+    --accent-foreground: 0 0% 0%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
-    --border: 155 10% 89%;
-    --input: 155 10% 85%;
-    --ring: 156 65% 30%;
+    --border: 0 0% 90%;
+    --input: 0 0% 90%;
+    --ring: 0 0% 0%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 165 8% 7%;
-    --foreground: 150 10% 92%;
-    --card: 165 8% 9%;
-    --card-foreground: 150 10% 92%;
-    --popover: 165 8% 9%;
-    --popover-foreground: 150 10% 92%;
-    --primary: 152 55% 52%;
-    --primary-foreground: 165 30% 8%;
-    --secondary: 165 7% 12%;
-    --secondary-foreground: 150 10% 92%;
-    --muted: 165 7% 12%;
-    --muted-foreground: 155 6% 58%;
-    --accent: 165 7% 15%;
-    --accent-foreground: 150 10% 92%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
+    --card: 0 0% 0%;
+    --card-foreground: 0 0% 100%;
+    --popover: 0 0% 4%;
+    --popover-foreground: 0 0% 100%;
+    --primary: 0 0% 100%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 0 0% 10%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 0 0% 10%;
+    --muted-foreground: 0 0% 60%;
+    --accent: 0 0% 10%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 62% 52%;
     --destructive-foreground: 0 0% 100%;
-    --border: 165 6% 16%;
-    --input: 165 6% 20%;
-    --ring: 152 55% 52%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 100%;
   }
 }
 

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -31,7 +31,7 @@
     --foreground: 0 0% 100%;
     --card: 0 0% 0%;
     --card-foreground: 0 0% 100%;
-    --popover: 0 0% 4%;
+    --popover: 0 0% 0%;
     --popover-foreground: 0 0% 100%;
     --primary: 0 0% 100%;
     --primary-foreground: 0 0% 0%;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -175,9 +175,8 @@ function App() {
     return (
       <div className="h-screen flex flex-col bg-background">
         {/* Header */}
-        <header className="h-12 border-b flex items-center justify-between px-4 flex-shrink-0">
+        <header className="h-12 border-b flex items-center justify-between px-3 flex-shrink-0">
           <div className="flex items-center gap-2">
-            <span className="h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
             <h1 className="text-sm font-semibold tracking-tight">VibeTree</h1>
           </div>
           <div className="flex items-center gap-1">
@@ -206,7 +205,7 @@ function App() {
       {showSuccessNotification && (
         <div className="border-b bg-muted/40 px-4 py-1.5">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <CheckCircle className="h-3.5 w-3.5 text-primary" />
+            <CheckCircle className="h-3.5 w-3.5" />
             <span>{successMessage}</span>
             <button
               onClick={() => setShowSuccessNotification(false)}
@@ -220,9 +219,8 @@ function App() {
       )}
 
       {/* Header */}
-      <header className="h-12 border-b flex items-center justify-between px-4 flex-shrink-0">
+      <header className="h-12 border-b flex items-center justify-between px-3 flex-shrink-0">
         <div className="flex items-center gap-2">
-          <span className="h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
           <h1 className="text-sm font-semibold tracking-tight">VibeTree</h1>
         </div>
         <div className="flex items-center gap-1">
@@ -245,7 +243,7 @@ function App() {
         onValueChange={setActiveProject}
         className="flex-1 flex flex-col"
       >
-        <div className="border-b flex items-center gap-1 bg-muted/30 h-9 px-2">
+        <div className="border-b flex items-center gap-1 h-9 px-2">
           <TabsList className="h-full bg-transparent p-0 rounded-none gap-1">
             {projects.map((project) => (
               <TabsTrigger

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,7 +9,7 @@ import { OnboardingHint } from './components/OnboardingHint';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@vibetree/ui';
 import { useAppStore } from './store';
 import { useWebSocket } from './hooks/useWebSocket';
-import { Sun, Moon, Plus, X, Terminal, GitBranch, CheckCircle } from 'lucide-react';
+import { Sun, Moon, Plus, X, CheckCircle } from 'lucide-react';
 import { autoLoadProjects } from './services/projectValidation';
 
 function App() {
@@ -175,20 +175,20 @@ function App() {
     return (
       <div className="h-screen flex flex-col bg-background">
         {/* Header */}
-        <header className="h-14 border-b flex items-center justify-between px-4 flex-shrink-0">
+        <header className="h-12 border-b flex items-center justify-between px-4 flex-shrink-0">
           <div className="flex items-center gap-2">
-            <h1 className="text-lg font-semibold">VibeTree</h1>
-            <span className="text-xs text-muted-foreground hidden sm:inline">Web Terminal</span>
+            <span className="h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
+            <h1 className="text-sm font-semibold tracking-tight">VibeTree</h1>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
+            <ConnectionStatus />
             <button
               onClick={toggleTheme}
-              className="p-2 hover:bg-accent rounded-md transition-colors"
+              className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
               aria-label="Toggle theme"
             >
               {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </button>
-            <ConnectionStatus />
           </div>
         </header>
 
@@ -204,13 +204,14 @@ function App() {
     <div className="h-screen flex flex-col bg-background">
       {/* Success Notification Banner */}
       {showSuccessNotification && (
-        <div className="bg-green-50 dark:bg-green-900/20 border-b border-green-200 dark:border-green-800 px-4 py-2">
-          <div className="flex items-center gap-2 text-green-700 dark:text-green-300">
-            <CheckCircle className="h-4 w-4" />
-            <span className="text-sm font-medium">{successMessage}</span>
+        <div className="border-b bg-muted/40 px-4 py-1.5">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <CheckCircle className="h-3.5 w-3.5 text-primary" />
+            <span>{successMessage}</span>
             <button
               onClick={() => setShowSuccessNotification(false)}
-              className="ml-auto hover:bg-green-100 dark:hover:bg-green-800/30 rounded p-1"
+              className="ml-auto hover:bg-accent rounded p-1"
+              aria-label="Dismiss"
             >
               <X className="h-3 w-3" />
             </button>
@@ -219,20 +220,20 @@ function App() {
       )}
 
       {/* Header */}
-      <header className="h-14 border-b flex items-center justify-between px-4 flex-shrink-0">
+      <header className="h-12 border-b flex items-center justify-between px-4 flex-shrink-0">
         <div className="flex items-center gap-2">
-          <h1 className="text-lg font-semibold">VibeTree</h1>
-          <span className="text-xs text-muted-foreground hidden sm:inline">Web Terminal</span>
+          <span className="h-2 w-2 rounded-full bg-primary" aria-hidden="true" />
+          <h1 className="text-sm font-semibold tracking-tight">VibeTree</h1>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <ConnectionStatus />
           <button
             onClick={toggleTheme}
-            className="p-2 hover:bg-accent rounded-md transition-colors"
+            className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
             aria-label="Toggle theme"
           >
             {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
           </button>
-          <ConnectionStatus />
         </div>
       </header>
 
@@ -244,17 +245,17 @@ function App() {
         onValueChange={setActiveProject}
         className="flex-1 flex flex-col"
       >
-        <div className="border-b flex items-center gap-2 bg-muted/50 h-10">
-          <TabsList className="h-full bg-transparent p-0 rounded-none">
+        <div className="border-b flex items-center gap-1 bg-muted/30 h-9 px-2">
+          <TabsList className="h-full bg-transparent p-0 rounded-none gap-1">
             {projects.map((project) => (
               <TabsTrigger
                 key={project.id}
                 value={project.id}
-                className="relative pr-8 h-full data-[state=active]:bg-background data-[state=active]:rounded-t-md data-[state=active]:border-t data-[state=active]:border-x data-[state=active]:border-b-0"
+                className="relative my-1 h-7 rounded-md px-2.5 pr-7 text-xs font-medium text-muted-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:border data-[state=active]:shadow-sm"
               >
                 {project.name}
                 <span
-                  className="absolute right-1 top-1/2 -translate-y-1/2 h-5 w-5 p-0.5 hover:bg-muted rounded cursor-pointer inline-flex items-center justify-center"
+                  className="absolute right-1 top-1/2 -translate-y-1/2 h-4 w-4 p-0.5 hover:bg-muted rounded cursor-pointer inline-flex items-center justify-center"
                   onClick={(e) => handleCloseProject(e, project.id)}
                 >
                   <X className="h-3 w-3" />
@@ -264,7 +265,7 @@ function App() {
           </TabsList>
           <button
             onClick={() => setShowProjectSelector(true)}
-            className="h-8 w-8 p-0 hover:bg-accent rounded transition-colors inline-flex items-center justify-center"
+            className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors inline-flex items-center justify-center"
             aria-label="Add project"
           >
             <Plus className="h-4 w-4" />
@@ -284,63 +285,41 @@ function App() {
                 <WorktreePanel projectId={project.id} />
               </div>
 
-              {/* Main Content Area with Tabs - Only shown when worktree is selected */}
+              {/* Main content; the Terminal/Changes switch lives in each view's toolbar */}
               {project.selectedWorktree ? (
-                <div className="flex-1 flex flex-col h-full">
-                  {/* Tab Navigation */}
-                  <div className="h-10 border-b flex items-center px-2 bg-muted/30 flex-shrink-0">
-                    <div className="flex">
-                      <button
-                        className={`px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-1.5 ${
-                          project.selectedTab === 'terminal'
-                            ? 'bg-background text-foreground border shadow-sm'
-                            : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-                        }`}
-                        onClick={() => setSelectedTab(project.id, 'terminal')}
-                      >
-                        <Terminal className="h-3.5 w-3.5" />
-                        Terminal
-                      </button>
-                      <button
-                        className={`px-3 py-1.5 text-sm rounded-md transition-colors flex items-center gap-1.5 ml-1 ${
-                          project.selectedTab === 'changes'
-                            ? 'bg-background text-foreground border shadow-sm'
-                            : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-                        }`}
-                        onClick={() => setSelectedTab(project.id, 'changes')}
-                      >
-                        <GitBranch className="h-3.5 w-3.5" />
-                        Changes
-                      </button>
-                    </div>
+                <div className="flex-1 overflow-hidden relative">
+                  <div
+                    className={`absolute inset-0 ${project.selectedTab === 'terminal' ? 'block' : 'hidden'}`}
+                  >
+                    <TerminalManager
+                      worktrees={project.worktrees || []}
+                      selectedWorktree={project.selectedWorktree}
+                      viewTab={project.selectedTab === 'changes' ? 'changes' : 'terminal'}
+                      onViewTabChange={(tab) => setSelectedTab(project.id, tab)}
+                    />
                   </div>
 
-                  {/* Tab Content */}
-                  <div className="flex-1 overflow-hidden relative">
-                    {/* Terminal Tab - Managed terminals with lifecycle control */}
-                    <div
-                      className={`absolute inset-0 ${project.selectedTab === 'terminal' ? 'block' : 'hidden'}`}
-                    >
-                      <TerminalManager
-                        worktrees={project.worktrees || []}
-                        selectedWorktree={project.selectedWorktree}
-                      />
-                    </div>
-
-                    {/* Keep GitDiffView mounted but hidden to preserve state */}
-                    <div
-                      className={`absolute inset-0 ${project.selectedTab === 'changes' ? 'block' : 'hidden'}`}
-                    >
-                      <GitDiffView worktreePath={project.selectedWorktree} theme={theme} />
-                    </div>
+                  {/* Keep GitDiffView mounted but hidden to preserve state */}
+                  <div
+                    className={`absolute inset-0 ${project.selectedTab === 'changes' ? 'block' : 'hidden'}`}
+                  >
+                    <GitDiffView
+                      worktreePath={project.selectedWorktree}
+                      theme={theme}
+                      viewTab={project.selectedTab === 'changes' ? 'changes' : 'terminal'}
+                      onViewTabChange={(tab) => setSelectedTab(project.id, tab)}
+                    />
                   </div>
                 </div>
               ) : (
                 /* Empty state when no worktree selected */
-                <div className="hidden md:flex flex-1 items-center justify-center text-muted-foreground">
-                  <div className="text-center">
-                    <p className="text-lg mb-2">Select a worktree to start</p>
-                    <p className="text-sm">Choose from the panel on the left</p>
+                <div className="hidden md:flex flex-1 items-center justify-center">
+                  <div className="text-center max-w-xs">
+                    <p className="text-sm font-medium mb-1">Pick a worktree to open its terminal</p>
+                    <p className="text-xs text-muted-foreground">
+                      Each worktree is an isolated checkout with its own branch and session. Create
+                      one per task or agent with the + button.
+                    </p>
                   </div>
                 </div>
               )}

--- a/apps/web/src/components/ConnectionStatus.tsx
+++ b/apps/web/src/components/ConnectionStatus.tsx
@@ -12,7 +12,7 @@ export function ConnectionStatus() {
     : error
       ? { dot: 'bg-destructive', label: 'Disconnected' }
       : connected
-        ? { dot: 'bg-primary', label: 'Connected' }
+        ? { dot: 'bg-green-500', label: 'Connected' }
         : null;
 
   if (!state) return null;

--- a/apps/web/src/components/ConnectionStatus.tsx
+++ b/apps/web/src/components/ConnectionStatus.tsx
@@ -1,34 +1,26 @@
 import { useAppStore } from '../store';
 
+/**
+ * Connection pill: state is encoded in the dot, the label stays neutral so
+ * the header does not fight the accent color.
+ */
 export function ConnectionStatus() {
   const { connected, connecting, error } = useAppStore();
 
-  if (connecting) {
-    return (
-      <div className="flex items-center gap-2">
-        <div className="w-2 h-2 bg-yellow-500 rounded-full animate-pulse" />
-        <span className="text-xs text-muted-foreground">Connecting...</span>
-      </div>
-    );
-  }
+  const state = connecting
+    ? { dot: 'bg-yellow-500 animate-pulse', label: 'Connecting' }
+    : error
+      ? { dot: 'bg-destructive', label: 'Disconnected' }
+      : connected
+        ? { dot: 'bg-primary', label: 'Connected' }
+        : null;
 
-  if (error) {
-    return (
-      <div className="flex items-center gap-2">
-        <div className="w-2 h-2 bg-red-500 rounded-full" />
-        <span className="text-xs text-red-500">Disconnected</span>
-      </div>
-    );
-  }
+  if (!state) return null;
 
-  if (connected) {
-    return (
-      <div className="flex items-center gap-2">
-        <div className="w-2 h-2 bg-green-500 rounded-full" />
-        <span className="text-xs text-green-500">Connected</span>
-      </div>
-    );
-  }
-
-  return null;
+  return (
+    <div className="flex items-center gap-1.5 h-6 px-2 rounded-full border text-[11px] text-muted-foreground">
+      <span className={`w-1.5 h-1.5 rounded-full ${state.dot}`} />
+      {state.label}
+    </div>
+  );
 }

--- a/apps/web/src/components/GitDiffView.tsx
+++ b/apps/web/src/components/GitDiffView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { RefreshCw, FileText } from 'lucide-react';
+import { ViewSwitch, type ViewTab } from './ViewSwitch';
 import { DiffView, DiffModeEnum } from '@git-diff-view/react';
 import '@git-diff-view/react/styles/diff-view.css';
 // import { useAppStore } from '../store';
@@ -16,9 +17,11 @@ interface GitFile {
 interface GitDiffViewProps {
   worktreePath: string;
   theme?: 'light' | 'dark';
+  viewTab: ViewTab;
+  onViewTabChange: (tab: ViewTab) => void;
 }
 
-export function GitDiffView({ worktreePath, theme = 'light' }: GitDiffViewProps) {
+export function GitDiffView({ worktreePath, theme = 'light' , viewTab, onViewTabChange }: GitDiffViewProps) {
   const [files, setFiles] = useState<GitFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [diffText, setDiffText] = useState<string>('');
@@ -133,31 +136,31 @@ export function GitDiffView({ worktreePath, theme = 'light' }: GitDiffViewProps)
 
   return (
     <div className="flex-1 flex flex-col h-full">
-      {/* Header */}
-      <div className="h-14 px-4 border-b flex items-center justify-between flex-shrink-0">
-        <div className="min-w-0 flex-1">
-          <h3 className="font-semibold">Git Changes</h3>
-          <p className="text-xs text-muted-foreground truncate">
-            {worktreePath.split('/').slice(-2).join('/')}
-          </p>
+      {/* Single toolbar: view switch, worktree identity, diff controls */}
+      <div className="h-10 px-2 border-b flex items-center justify-between gap-2 flex-shrink-0 bg-background">
+        <div className="flex items-center gap-2 min-w-0">
+          <ViewSwitch active={viewTab} onChange={onViewTabChange} />
+          <span className="font-mono text-xs text-muted-foreground truncate min-w-0">
+            {worktreePath.split('/').slice(-1)[0]}
+          </span>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="flex border rounded-md">
+        <div className="flex items-center gap-1">
+          <div className="flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5">
             <button
-              className={`px-3 py-1 text-sm rounded-l-md transition-colors ${
+              className={`px-2.5 h-6 text-xs font-medium rounded transition-colors ${
                 viewMode === 'unstaged'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-background hover:bg-muted'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
               onClick={() => setViewMode('unstaged')}
             >
               Unstaged
             </button>
             <button
-              className={`px-3 py-1 text-sm rounded-r-md border-l transition-colors ${
+              className={`px-2.5 h-6 text-xs font-medium rounded transition-colors ${
                 viewMode === 'staged'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-background hover:bg-muted'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
               onClick={() => setViewMode('staged')}
             >
@@ -167,7 +170,8 @@ export function GitDiffView({ worktreePath, theme = 'light' }: GitDiffViewProps)
           <button
             onClick={loadGitStatus}
             disabled={loading}
-            className="p-2 hover:bg-accent rounded transition-colors disabled:opacity-50"
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors disabled:opacity-50"
+            aria-label="Refresh changes"
           >
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           </button>
@@ -177,10 +181,10 @@ export function GitDiffView({ worktreePath, theme = 'light' }: GitDiffViewProps)
       <div className="flex-1 flex min-h-0 overflow-hidden">
         {/* File List */}
         <div className="w-80 border-r flex flex-col min-w-0">
-          <div className="p-3 border-b bg-muted/50">
-            <h4 className="text-sm font-medium">
-              {viewMode === 'staged' ? 'Staged Changes' : 'Unstaged Changes'} (
-              {filteredFiles.length})
+          <div className="px-3 py-2 border-b">
+            <h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              {viewMode === 'staged' ? 'Staged' : 'Unstaged'}
+              <span className="ml-1.5 font-normal">{filteredFiles.length}</span>
             </h4>
           </div>
           <div className="flex-1 overflow-auto">

--- a/apps/web/src/components/GitDiffView.tsx
+++ b/apps/web/src/components/GitDiffView.tsx
@@ -137,7 +137,7 @@ export function GitDiffView({ worktreePath, theme = 'light' , viewTab, onViewTab
   return (
     <div className="flex-1 flex flex-col h-full">
       {/* Single toolbar: view switch, worktree identity, diff controls */}
-      <div className="h-10 px-2 border-b flex items-center justify-between gap-2 flex-shrink-0 bg-background">
+      <div className="h-9 px-3 border-b flex items-center justify-between gap-2 flex-shrink-0 bg-background">
         <div className="flex items-center gap-2 min-w-0">
           <ViewSwitch active={viewTab} onChange={onViewTabChange} />
           <span className="font-mono text-xs text-muted-foreground truncate min-w-0">
@@ -145,11 +145,11 @@ export function GitDiffView({ worktreePath, theme = 'light' , viewTab, onViewTab
           </span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5">
+          <div className="flex items-center gap-0.5 rounded-md bg-muted p-0.5">
             <button
               className={`px-2.5 h-6 text-xs font-medium rounded transition-colors ${
                 viewMode === 'unstaged'
-                  ? 'bg-background text-foreground shadow-sm'
+                  ? 'bg-background text-foreground border shadow-sm'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
               onClick={() => setViewMode('unstaged')}
@@ -159,7 +159,7 @@ export function GitDiffView({ worktreePath, theme = 'light' , viewTab, onViewTab
             <button
               className={`px-2.5 h-6 text-xs font-medium rounded transition-colors ${
                 viewMode === 'staged'
-                  ? 'bg-background text-foreground shadow-sm'
+                  ? 'bg-background text-foreground border shadow-sm'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
               onClick={() => setViewMode('staged')}
@@ -181,7 +181,7 @@ export function GitDiffView({ worktreePath, theme = 'light' , viewTab, onViewTab
       <div className="flex-1 flex min-h-0 overflow-hidden">
         {/* File List */}
         <div className="w-80 border-r flex flex-col min-w-0">
-          <div className="px-3 py-2 border-b">
+          <div className="h-9 px-3 border-b flex items-center">
             <h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
               {viewMode === 'staged' ? 'Staged' : 'Unstaged'}
               <span className="ml-1.5 font-normal">{filteredFiles.length}</span>

--- a/apps/web/src/components/OnboardingHint.tsx
+++ b/apps/web/src/components/OnboardingHint.tsx
@@ -33,15 +33,15 @@ export function OnboardingHint() {
       </p>
       <ul className="mt-3 space-y-1.5 text-xs text-muted-foreground">
         <li className="flex items-center gap-2">
-          <GitBranch className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
+          <GitBranch className="h-3.5 w-3.5 flex-shrink-0" />
           Create a worktree per task; each gets its own branch and directory
         </li>
         <li className="flex items-center gap-2">
-          <TerminalSquare className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
+          <TerminalSquare className="h-3.5 w-3.5 flex-shrink-0" />
           Open its terminal and launch your agent; sessions survive page reloads
         </li>
         <li className="flex items-center gap-2">
-          <Smartphone className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
+          <Smartphone className="h-3.5 w-3.5 flex-shrink-0" />
           Install this page as an app to check on your agents from your phone
         </li>
       </ul>

--- a/apps/web/src/components/OnboardingHint.tsx
+++ b/apps/web/src/components/OnboardingHint.tsx
@@ -14,36 +14,38 @@ export function OnboardingHint() {
   };
 
   return (
-    <div className="mx-4 mt-4 rounded-lg border bg-muted/30 p-4" data-testid="onboarding-hint">
+    <div className="mx-auto w-full max-w-2xl mt-4 px-4" data-testid="onboarding-hint">
+      <div className="rounded-lg border bg-card p-4">
       <div className="flex items-start justify-between gap-2">
-        <h3 className="font-semibold">Welcome to VibeTree</h3>
+        <h3 className="text-sm font-semibold">Welcome to VibeTree</h3>
         <button
           onClick={dismiss}
-          className="p-1 hover:bg-accent rounded"
+          className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded"
           aria-label="Dismiss welcome hint"
           data-testid="onboarding-dismiss"
         >
           <X className="h-4 w-4" />
         </button>
       </div>
-      <p className="text-sm text-muted-foreground mt-1">
+      <p className="text-xs text-muted-foreground mt-1">
         Run AI coding agents in parallel git worktrees, from any device. Works with Claude Code,
         Codex, Gemini CLI, Aider, or any terminal program.
       </p>
-      <ul className="mt-3 space-y-1.5 text-sm text-muted-foreground">
+      <ul className="mt-3 space-y-1.5 text-xs text-muted-foreground">
         <li className="flex items-center gap-2">
-          <GitBranch className="h-4 w-4 flex-shrink-0" />
+          <GitBranch className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
           Create a worktree per task; each gets its own branch and directory
         </li>
         <li className="flex items-center gap-2">
-          <TerminalSquare className="h-4 w-4 flex-shrink-0" />
+          <TerminalSquare className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
           Open its terminal and launch your agent; sessions survive page reloads
         </li>
         <li className="flex items-center gap-2">
-          <Smartphone className="h-4 w-4 flex-shrink-0" />
+          <Smartphone className="h-3.5 w-3.5 flex-shrink-0 text-primary" />
           Install this page as an app to check on your agents from your phone
         </li>
       </ul>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/ProjectSelector.tsx
+++ b/apps/web/src/components/ProjectSelector.tsx
@@ -34,8 +34,8 @@ export function ProjectSelector({ onSelectProject }: ProjectSelectorProps) {
     <div className="flex-1 flex items-center justify-center p-8">
       <div className="w-full max-w-md space-y-6">
         <div className="text-center space-y-2">
-          <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mx-auto">
-            <FolderOpen className="h-6 w-6 text-primary" />
+          <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center mx-auto">
+            <FolderOpen className="h-6 w-6 text-muted-foreground" />
           </div>
           <h2 className="text-xl font-semibold tracking-tight">Open a project</h2>
           <p className="text-sm text-muted-foreground">
@@ -58,7 +58,7 @@ export function ProjectSelector({ onSelectProject }: ProjectSelectorProps) {
               value={projectPath}
               onChange={(e) => setProjectPath(e.target.value)}
               placeholder="/path/to/your/project"
-              className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+              className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/15 focus:border-foreground/30"
               disabled={isLoading}
             />
             {error && <p className="text-xs text-destructive">{error}</p>}

--- a/apps/web/src/components/ProjectSelector.tsx
+++ b/apps/web/src/components/ProjectSelector.tsx
@@ -34,19 +34,23 @@ export function ProjectSelector({ onSelectProject }: ProjectSelectorProps) {
     <div className="flex-1 flex items-center justify-center p-8">
       <div className="w-full max-w-md space-y-6">
         <div className="text-center space-y-2">
-          <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto">
-            <FolderOpen className="h-8 w-8 text-muted-foreground" />
+          <div className="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center mx-auto">
+            <FolderOpen className="h-6 w-6 text-primary" />
           </div>
-          <h2 className="text-2xl font-bold">Select a Project</h2>
-          <p className="text-muted-foreground">
-            Enter the path to your git repository to start working with Claude in parallel worktrees
+          <h2 className="text-xl font-semibold tracking-tight">Open a project</h2>
+          <p className="text-sm text-muted-foreground">
+            Point VibeTree at a git repository on the server. Every task gets its own worktree
+            with a persistent terminal for your AI agent.
           </p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <label htmlFor="projectPath" className="text-sm font-medium">
-              Project Path
+            <label
+              htmlFor="projectPath"
+              className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+            >
+              Project path
             </label>
             <input
               id="projectPath"
@@ -54,16 +58,16 @@ export function ProjectSelector({ onSelectProject }: ProjectSelectorProps) {
               value={projectPath}
               onChange={(e) => setProjectPath(e.target.value)}
               placeholder="/path/to/your/project"
-              className="w-full px-3 py-2 border border-input bg-background rounded-md text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+              className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
               disabled={isLoading}
             />
-            {error && <p className="text-sm text-red-500">{error}</p>}
+            {error && <p className="text-xs text-destructive">{error}</p>}
           </div>
 
           <button
             type="submit"
             disabled={isLoading || !projectPath.trim()}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="w-full h-9 flex items-center justify-center gap-2 bg-primary text-primary-foreground rounded-md text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <Plus className="h-4 w-4" />
             {isLoading ? 'Adding Project...' : 'Add Project'}
@@ -72,7 +76,7 @@ export function ProjectSelector({ onSelectProject }: ProjectSelectorProps) {
 
         <div className="text-center">
           <p className="text-xs text-muted-foreground">
-            Make sure the path points to a valid git repository
+            The path must point to a git repository the server can reach
           </p>
         </div>
       </div>

--- a/apps/web/src/components/TerminalManager.tsx
+++ b/apps/web/src/components/TerminalManager.tsx
@@ -1,15 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
 import { TerminalView } from './TerminalView';
+import type { ViewTab } from './ViewSwitch';
 
 interface TerminalManagerProps {
   worktrees: Array<{ path: string; branch?: string; head: string }>;
   selectedWorktree: string | null;
+  viewTab: ViewTab;
+  onViewTabChange: (tab: ViewTab) => void;
 }
 
 // Component cache to maintain terminal instances
 // const terminalComponents = new Map<string, React.ComponentType>();
 
-export function TerminalManager({ worktrees, selectedWorktree }: TerminalManagerProps) {
+export function TerminalManager({
+  worktrees,
+  selectedWorktree,
+  viewTab,
+  onViewTabChange
+}: TerminalManagerProps) {
   const [mountedTerminals, setMountedTerminals] = useState<Set<string>>(new Set());
 
   // Track which terminals have been created
@@ -46,10 +54,12 @@ export function TerminalManager({ worktrees, selectedWorktree }: TerminalManager
 
   if (!selectedWorktree) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground">
-        <div className="text-center">
-          <p className="text-lg mb-2">Select a worktree to start</p>
-          <p className="text-sm">Choose from the panel on the left</p>
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center max-w-xs">
+          <p className="text-sm font-medium mb-1">Pick a worktree to open its terminal</p>
+          <p className="text-xs text-muted-foreground">
+            Each worktree is an isolated checkout with its own branch and session.
+          </p>
         </div>
       </div>
     );
@@ -71,7 +81,7 @@ export function TerminalManager({ worktrees, selectedWorktree }: TerminalManager
             height: '100%'
           }}
         >
-          <TerminalView worktreePath={worktreePath} />
+          <TerminalView worktreePath={worktreePath} viewTab={viewTab} onViewTabChange={onViewTabChange} />
         </div>
       ))}
     </div>

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -445,7 +445,7 @@ export function TerminalView({ worktreePath, viewTab, onViewTabChange }: Termina
   return (
     <div className={`flex flex-col w-full h-full ${isFullscreen ? 'fixed inset-0 z-50 bg-background' : ''}`}>
       {/* Single toolbar: view switch, worktree identity, terminal actions */}
-      <div className="h-10 px-2 border-b flex items-center justify-between gap-2 flex-shrink-0 bg-background">
+      <div className="h-9 px-3 border-b flex items-center justify-between gap-2 flex-shrink-0 bg-background">
         <div className="flex items-center gap-2 min-w-0">
           <button
             onClick={handleBack}

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -4,15 +4,18 @@ import { useAppStore } from '../store';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { ChevronLeft, Maximize2, Minimize2, Columns2, X } from 'lucide-react';
 import type { Terminal as XTerm } from '@xterm/xterm';
+import { ViewSwitch, type ViewTab } from './ViewSwitch';
 
 // Cache for terminal states per session ID (like desktop app)
 const terminalStateCache = new Map<string, string>();
 
 interface TerminalViewProps {
   worktreePath: string;
+  viewTab: ViewTab;
+  onViewTabChange: (tab: ViewTab) => void;
 }
 
-export function TerminalView({ worktreePath }: TerminalViewProps) {
+export function TerminalView({ worktreePath, viewTab, onViewTabChange }: TerminalViewProps) {
   const {
     getActiveProject,
     setSelectedWorktree,
@@ -440,77 +443,53 @@ export function TerminalView({ worktreePath }: TerminalViewProps) {
   if (!selectedWorktree) return null;
 
   return (
-    <div className={`flex flex-col w-full h-full ${isFullscreen ? 'fixed inset-0 z-50' : ''}`}>
-      {/* Terminal Headers */}
-      <div className={`flex ${isSplit ? 'flex-row' : ''} bg-background`}>
-        <div
-          className={`${isSplit ? 'w-1/2' : 'w-full'} h-14 px-4 border-b flex items-center justify-between flex-shrink-0`}
-        >
-          <div className="flex items-center gap-2 min-w-0">
-            <button
-              onClick={handleBack}
-              className="md:hidden p-1 hover:bg-accent rounded flex-shrink-0"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            <div className="min-w-0">
-              <h3 className="font-semibold truncate">Terminal</h3>
-              <p className="text-xs text-muted-foreground truncate">
-                {selectedWorktree?.split('/').slice(-2).join('/')}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={toggleSplit}
-              className="p-1 hover:bg-accent rounded"
-              title="Split Terminal"
-            >
-              <Columns2 className="h-4 w-4" />
-            </button>
-            <button
-              onClick={toggleFullscreen}
-              className="p-1 hover:bg-accent rounded"
-              title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
-            >
-              {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-            </button>
-          </div>
+    <div className={`flex flex-col w-full h-full ${isFullscreen ? 'fixed inset-0 z-50 bg-background' : ''}`}>
+      {/* Single toolbar: view switch, worktree identity, terminal actions */}
+      <div className="h-10 px-2 border-b flex items-center justify-between gap-2 flex-shrink-0 bg-background">
+        <div className="flex items-center gap-2 min-w-0">
+          <button
+            onClick={handleBack}
+            className="md:hidden p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded flex-shrink-0"
+            aria-label="Back to worktrees"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <ViewSwitch active={viewTab} onChange={onViewTabChange} />
+          <span className="font-mono text-xs text-muted-foreground truncate min-w-0">
+            {selectedWorktree?.split('/').slice(-1)[0]}
+            {isSplit ? ' (split)' : ''}
+          </span>
         </div>
-        {/* Split terminal header */}
-        {isSplit && (
-          <div className="w-1/2 h-14 px-4 border-b border-l flex items-center justify-between flex-shrink-0">
-            <div className="flex items-center gap-2 min-w-0">
-              <div className="min-w-0">
-                <h3 className="font-semibold truncate">Terminal (Split)</h3>
-                <p className="text-xs text-muted-foreground truncate">
-                  {selectedWorktree?.split('/').slice(-2).join('/')}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={toggleSplit}
-                className="p-1 hover:bg-accent rounded"
-                title="Split Terminal"
-              >
-                <Columns2 className="h-4 w-4" />
-              </button>
-              <button
-                onClick={closeSplitTerminal}
-                className="p-1 hover:bg-accent rounded"
-                title="Close Split Terminal"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
-        )}
+        <div className="flex items-center gap-0.5">
+          <button
+            onClick={toggleSplit}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded"
+            title="Split Terminal"
+          >
+            <Columns2 className="h-4 w-4" />
+          </button>
+          {isSplit && (
+            <button
+              onClick={closeSplitTerminal}
+              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded"
+              title="Close Split Terminal"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+          <button
+            onClick={toggleFullscreen}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded"
+            title={isFullscreen ? 'Exit Fullscreen' : 'Fullscreen'}
+          >
+            {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </button>
+        </div>
       </div>
 
       {/* Terminal Container */}
       <div
-        className={`flex-1 flex ${isSplit ? 'flex-row' : ''} ${theme === 'light' ? 'bg-white' : 'bg-black'}`}
+        className={`flex-1 flex ${isSplit ? 'flex-row' : ''} bg-background`}
       >
         <div className={`${isSplit ? 'w-1/2 border-r' : 'w-full'} h-full`}>
           {sessionId && (
@@ -527,7 +506,7 @@ export function TerminalView({ worktreePath }: TerminalViewProps) {
             />
           )}
           {!sessionId && (
-            <div className="flex items-center justify-center h-full text-muted-foreground">
+            <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
               <p>Starting terminal session...</p>
             </div>
           )}
@@ -548,7 +527,7 @@ export function TerminalView({ worktreePath }: TerminalViewProps) {
               />
             )}
             {!splitSessionId && (
-              <div className="flex items-center justify-center h-full text-muted-foreground">
+              <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
                 <p>Starting split terminal session...</p>
               </div>
             )}

--- a/apps/web/src/components/ViewSwitch.tsx
+++ b/apps/web/src/components/ViewSwitch.tsx
@@ -15,11 +15,11 @@ export function ViewSwitch({ active, onChange }: ViewSwitchProps) {
   const base =
     'flex items-center gap-1.5 px-2.5 h-6 text-xs font-medium rounded transition-colors';
   return (
-    <div className="flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5">
+    <div className="flex items-center gap-0.5 rounded-md bg-muted p-0.5">
       <button
         className={`${base} ${
           active === 'terminal'
-            ? 'bg-background text-foreground shadow-sm'
+            ? 'bg-background text-foreground border shadow-sm'
             : 'text-muted-foreground hover:text-foreground'
         }`}
         onClick={() => onChange('terminal')}
@@ -30,7 +30,7 @@ export function ViewSwitch({ active, onChange }: ViewSwitchProps) {
       <button
         className={`${base} ${
           active === 'changes'
-            ? 'bg-background text-foreground shadow-sm'
+            ? 'bg-background text-foreground border shadow-sm'
             : 'text-muted-foreground hover:text-foreground'
         }`}
         onClick={() => onChange('changes')}

--- a/apps/web/src/components/ViewSwitch.tsx
+++ b/apps/web/src/components/ViewSwitch.tsx
@@ -1,0 +1,43 @@
+import { Terminal, GitBranch } from 'lucide-react';
+
+export type ViewTab = 'terminal' | 'changes';
+
+interface ViewSwitchProps {
+  active: ViewTab;
+  onChange: (tab: ViewTab) => void;
+}
+
+/**
+ * Segmented Terminal/Changes control shown in each view's toolbar, so the
+ * app needs no separate tab bar row.
+ */
+export function ViewSwitch({ active, onChange }: ViewSwitchProps) {
+  const base =
+    'flex items-center gap-1.5 px-2.5 h-6 text-xs font-medium rounded transition-colors';
+  return (
+    <div className="flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5">
+      <button
+        className={`${base} ${
+          active === 'terminal'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+        onClick={() => onChange('terminal')}
+      >
+        <Terminal className="h-3.5 w-3.5" />
+        Terminal
+      </button>
+      <button
+        className={`${base} ${
+          active === 'changes'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+        onClick={() => onChange('changes')}
+      >
+        <GitBranch className="h-3.5 w-3.5" />
+        Changes
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorktreePanel.tsx
+++ b/apps/web/src/components/WorktreePanel.tsx
@@ -234,12 +234,12 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
 
       {/* Create New Branch Dialog */}
       {showNewBranchDialog && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50">
-          <div className="bg-popover text-popover-foreground border rounded-lg shadow-2xl w-full max-w-sm">
-            <div className="p-5">
-              <h3 className="text-sm font-semibold">New worktree</h3>
-              <p className="text-xs text-muted-foreground mt-1 mb-4">
-                Creates a branch and an isolated checkout next to your project.
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-background border rounded-lg shadow-lg w-full max-w-md">
+            <div className="p-6">
+              <h3 className="text-lg font-semibold mb-2">Create New Feature Branch</h3>
+              <p className="text-sm text-muted-foreground mb-4">
+                This will create a new git worktree for parallel development
               </p>
 
               <input
@@ -256,25 +256,24 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
                     setNewBranchName('');
                   }
                 }}
-                className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/15 focus:border-foreground/30"
+                className="w-full px-3 py-2 border border-input bg-background rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring"
                 autoFocus
-                spellCheck={false}
               />
 
-              <div className="flex justify-end gap-2 mt-5">
+              <div className="flex justify-end gap-2 mt-6">
                 <button
                   onClick={() => {
                     setShowNewBranchDialog(false);
                     setNewBranchName('');
                   }}
-                  className="h-8 px-3 text-xs font-medium border rounded-md hover:bg-accent transition-colors"
+                  className="px-4 py-2 text-sm border border-border rounded-md hover:bg-accent"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handleCreateBranch}
                   disabled={!newBranchName.trim() || loading}
-                  className="h-8 px-3 text-xs font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                  className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
                 >
                   {loading ? 'Creating...' : 'Create Branch'}
                 </button>

--- a/apps/web/src/components/WorktreePanel.tsx
+++ b/apps/web/src/components/WorktreePanel.tsx
@@ -128,39 +128,49 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
   return (
     <div className="flex flex-col h-full w-full">
       {/* Panel Header */}
-      <div className="h-14 px-4 border-b flex items-center justify-between flex-shrink-0">
-        <div className="flex items-center gap-2">
+      <div className="h-10 px-3 border-b flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
           {/* Back button on mobile when terminal is selected */}
           {project.selectedWorktree && (
-            <button onClick={handleBack} className="md:hidden p-1 hover:bg-accent rounded">
+            <button
+              onClick={handleBack}
+              className="md:hidden p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded"
+              aria-label="Back"
+            >
               <ChevronLeft className="h-4 w-4" />
             </button>
           )}
-          <h2 className="font-semibold">Worktrees</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Worktrees
+            <span className="ml-1.5 font-normal">{project.worktrees.length}</span>
+          </h2>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-0.5">
           <button
             onClick={handleRefresh}
             disabled={!connected || loading}
-            className="p-1 hover:bg-accent rounded disabled:opacity-50"
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded disabled:opacity-50"
+            aria-label="Refresh worktrees"
           >
-            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
           </button>
           <button
             onClick={() => setShowNewBranchDialog(true)}
             disabled={!connected}
-            className="p-1 hover:bg-accent rounded disabled:opacity-50"
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded disabled:opacity-50"
             aria-label="Create worktree"
             data-testid="create-worktree"
           >
-            <Plus className="h-4 w-4" />
+            <Plus className="h-3.5 w-3.5" />
           </button>
         </div>
       </div>
 
       {/* Project Path */}
-      <div className="px-4 py-2 border-b bg-muted/50">
-        <p className="text-xs text-muted-foreground truncate">{project.path}</p>
+      <div className="px-3 py-1.5 border-b">
+        <p className="font-mono text-[11px] text-muted-foreground truncate" title={project.path}>
+          {project.path}
+        </p>
       </div>
 
       {/* Worktree List */}
@@ -175,7 +185,7 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
             <p className="text-xs mt-2">Click the + button to create worktrees</p>
           </div>
         ) : (
-          <div className="p-2">
+          <div className="p-2 space-y-0.5">
             {[...project.worktrees]
               .sort((a, b) => {
                 // Extract branch names, handling refs/heads/ prefix and detached HEAD
@@ -200,29 +210,25 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
                   path: worktree.path,
                   isSelected: project.selectedWorktree === worktree.path
                 });
+                const isSelected = project.selectedWorktree === worktree.path;
                 return (
                   <button
                     key={worktree.path}
                     onClick={() => handleSelectWorktree(worktree.path)}
-                    className={`
-                    w-full text-left p-3 rounded-md mb-1 transition-colors
-                    ${
-                      project.selectedWorktree === worktree.path
-                        ? 'bg-accent'
-                        : 'hover:bg-accent/50'
-                    }
-                  `}
+                    className={`w-full text-left px-2 py-1.5 rounded-md transition-colors flex items-center gap-2 ${
+                      isSelected
+                        ? 'bg-accent text-foreground'
+                        : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+                    }`}
                   >
-                    <div className="flex items-start gap-2">
-                      <GitBranch className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <div className="truncate" style={{ fontSize: '21px', fontWeight: 'bold' }}>
-                          {worktree.branch
-                            ? worktree.branch.replace('refs/heads/', '')
-                            : `Detached HEAD (${worktree.head.substring(0, 8)})`}
-                        </div>
-                      </div>
-                    </div>
+                    <GitBranch
+                      className={`h-3.5 w-3.5 flex-shrink-0 ${isSelected ? 'text-primary' : ''}`}
+                    />
+                    <span className="font-mono text-[13px] font-medium truncate">
+                      {worktree.branch
+                        ? worktree.branch.replace('refs/heads/', '')
+                        : `detached (${worktree.head.substring(0, 8)})`}
+                    </span>
                   </button>
                 );
               })}
@@ -232,12 +238,12 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
 
       {/* Create New Branch Dialog */}
       {showNewBranchDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-background border rounded-lg shadow-lg w-full max-w-md">
-            <div className="p-6">
-              <h3 className="text-lg font-semibold mb-2">Create New Feature Branch</h3>
-              <p className="text-sm text-muted-foreground mb-4">
-                This will create a new git worktree for parallel development
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50">
+          <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg w-full max-w-sm">
+            <div className="p-5">
+              <h3 className="text-sm font-semibold">New worktree</h3>
+              <p className="text-xs text-muted-foreground mt-1 mb-4">
+                Creates a branch and an isolated checkout next to your project.
               </p>
 
               <input
@@ -254,24 +260,25 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
                     setNewBranchName('');
                   }
                 }}
-                className="w-full px-3 py-2 border border-input bg-background rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring"
+                className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
                 autoFocus
+                spellCheck={false}
               />
 
-              <div className="flex justify-end gap-2 mt-6">
+              <div className="flex justify-end gap-2 mt-5">
                 <button
                   onClick={() => {
                     setShowNewBranchDialog(false);
                     setNewBranchName('');
                   }}
-                  className="px-4 py-2 text-sm border border-border rounded-md hover:bg-accent"
+                  className="h-8 px-3 text-xs font-medium border rounded-md hover:bg-accent transition-colors"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handleCreateBranch}
                   disabled={!newBranchName.trim() || loading}
-                  className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
+                  className="h-8 px-3 text-xs font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50 transition-colors"
                 >
                   {loading ? 'Creating...' : 'Create Branch'}
                 </button>

--- a/apps/web/src/components/WorktreePanel.tsx
+++ b/apps/web/src/components/WorktreePanel.tsx
@@ -128,7 +128,7 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
   return (
     <div className="flex flex-col h-full w-full">
       {/* Panel Header */}
-      <div className="h-10 px-3 border-b flex items-center justify-between flex-shrink-0">
+      <div className="h-9 px-3 border-b flex items-center justify-between flex-shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           {/* Back button on mobile when terminal is selected */}
           {project.selectedWorktree && (
@@ -140,7 +140,10 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
               <ChevronLeft className="h-4 w-4" />
             </button>
           )}
-          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <h2
+            className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground truncate"
+            title={project.path}
+          >
             Worktrees
             <span className="ml-1.5 font-normal">{project.worktrees.length}</span>
           </h2>
@@ -164,13 +167,6 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
             <Plus className="h-3.5 w-3.5" />
           </button>
         </div>
-      </div>
-
-      {/* Project Path */}
-      <div className="px-3 py-1.5 border-b">
-        <p className="font-mono text-[11px] text-muted-foreground truncate" title={project.path}>
-          {project.path}
-        </p>
       </div>
 
       {/* Worktree List */}
@@ -222,7 +218,7 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
                     }`}
                   >
                     <GitBranch
-                      className={`h-3.5 w-3.5 flex-shrink-0 ${isSelected ? 'text-primary' : ''}`}
+                      className="h-3.5 w-3.5 flex-shrink-0"
                     />
                     <span className="font-mono text-[13px] font-medium truncate">
                       {worktree.branch
@@ -238,8 +234,8 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
 
       {/* Create New Branch Dialog */}
       {showNewBranchDialog && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50">
-          <div className="bg-popover text-popover-foreground border rounded-lg shadow-lg w-full max-w-sm">
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center p-4 z-50">
+          <div className="bg-popover text-popover-foreground border rounded-lg shadow-2xl w-full max-w-sm">
             <div className="p-5">
               <h3 className="text-sm font-semibold">New worktree</h3>
               <p className="text-xs text-muted-foreground mt-1 mb-4">
@@ -260,7 +256,7 @@ export function WorktreePanel({ projectId }: WorktreePanelProps) {
                     setNewBranchName('');
                   }
                 }}
-                className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+                className="w-full h-9 px-3 font-mono border border-input bg-background rounded-md text-[13px] placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/15 focus:border-foreground/30"
                 autoFocus
                 spellCheck={false}
               />

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2,50 +2,53 @@
 @tailwind components;
 @tailwind utilities;
 
+/* VibeTree palette: neutrals carry a slight green cast (the tool is a tree),
+   with one emerald accent reserved for primary actions and active state.
+   Both themes share the same token names; components never hardcode colors. */
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 168 15% 12%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 168 15% 12%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --popover-foreground: 168 15% 12%;
+    --primary: 156 65% 30%;
+    --primary-foreground: 150 40% 98%;
+    --secondary: 150 12% 96%;
+    --secondary-foreground: 168 15% 15%;
+    --muted: 150 12% 96%;
+    --muted-foreground: 160 6% 42%;
+    --accent: 150 12% 94%;
+    --accent-foreground: 168 15% 12%;
+    --destructive: 0 74% 48%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 155 10% 89%;
+    --input: 155 10% 85%;
+    --ring: 156 65% 30%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 0 0% 0%;
-    --foreground: 0 0% 100%;
-    --card: 0 0% 0%;
-    --card-foreground: 0 0% 100%;
-    --popover: 0 0% 0%;
-    --popover-foreground: 0 0% 100%;
-    --primary: 0 0% 100%;
-    --primary-foreground: 0 0% 0%;
-    --secondary: 0 0% 10%;
-    --secondary-foreground: 0 0% 100%;
-    --muted: 0 0% 10%;
-    --muted-foreground: 0 0% 60%;
-    --accent: 0 0% 10%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 0% 100%;
-    --destructive-foreground: 0 0% 0%;
-    --border: 0 0% 15%;
-    --input: 0 0% 15%;
-    --ring: 0 0% 100%;
+    --background: 165 8% 7%;
+    --foreground: 150 10% 92%;
+    --card: 165 8% 9%;
+    --card-foreground: 150 10% 92%;
+    --popover: 165 8% 9%;
+    --popover-foreground: 150 10% 92%;
+    --primary: 152 55% 52%;
+    --primary-foreground: 165 30% 8%;
+    --secondary: 165 7% 12%;
+    --secondary-foreground: 150 10% 92%;
+    --muted: 165 7% 12%;
+    --muted-foreground: 155 6% 58%;
+    --accent: 165 7% 15%;
+    --accent-foreground: 150 10% 92%;
+    --destructive: 0 62% 52%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 165 6% 16%;
+    --input: 165 6% 20%;
+    --ring: 152 55% 52%;
   }
 }
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -31,7 +31,7 @@
     --foreground: 0 0% 100%;
     --card: 0 0% 0%;
     --card-foreground: 0 0% 100%;
-    --popover: 0 0% 4%;
+    --popover: 0 0% 0%;
     --popover-foreground: 0 0% 100%;
     --primary: 0 0% 100%;
     --primary-foreground: 0 0% 0%;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2,53 +2,50 @@
 @tailwind components;
 @tailwind utilities;
 
-/* VibeTree palette: neutrals carry a slight green cast (the tool is a tree),
-   with one emerald accent reserved for primary actions and active state.
-   Both themes share the same token names; components never hardcode colors. */
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 168 15% 12%;
+    --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
-    --card-foreground: 168 15% 12%;
+    --card-foreground: 222.2 84% 4.9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 168 15% 12%;
-    --primary: 156 65% 30%;
-    --primary-foreground: 150 40% 98%;
-    --secondary: 150 12% 96%;
-    --secondary-foreground: 168 15% 15%;
-    --muted: 150 12% 96%;
-    --muted-foreground: 160 6% 42%;
-    --accent: 150 12% 94%;
-    --accent-foreground: 168 15% 12%;
-    --destructive: 0 74% 48%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 155 10% 89%;
-    --input: 155 10% 85%;
-    --ring: 156 65% 30%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: 165 8% 7%;
-    --foreground: 150 10% 92%;
-    --card: 165 8% 9%;
-    --card-foreground: 150 10% 92%;
-    --popover: 165 8% 9%;
-    --popover-foreground: 150 10% 92%;
-    --primary: 152 55% 52%;
-    --primary-foreground: 165 30% 8%;
-    --secondary: 165 7% 12%;
-    --secondary-foreground: 150 10% 92%;
-    --muted: 165 7% 12%;
-    --muted-foreground: 155 6% 58%;
-    --accent: 165 7% 15%;
-    --accent-foreground: 150 10% 92%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 100%;
+    --card: 0 0% 0%;
+    --card-foreground: 0 0% 100%;
+    --popover: 0 0% 4%;
+    --popover-foreground: 0 0% 100%;
+    --primary: 0 0% 100%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 0 0% 10%;
+    --secondary-foreground: 0 0% 100%;
+    --muted: 0 0% 10%;
+    --muted-foreground: 0 0% 60%;
+    --accent: 0 0% 10%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 0 62% 52%;
     --destructive-foreground: 0 0% 100%;
-    --border: 165 6% 16%;
-    --input: 165 6% 20%;
-    --ring: 152 55% 52%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 100%;
   }
 }
 

--- a/packages/ui/src/components/Terminal.tsx
+++ b/packages/ui/src/components/Terminal.tsx
@@ -89,10 +89,10 @@ const getTerminalTheme = (theme: 'light' | 'dark') => {
       brightWhite: '#e5e5e5'
     },
     dark: {
-      background: '#000000',
-      foreground: '#ffffff',
+      background: '#101312',
+      foreground: '#e6ebe9',
       cursor: '#ffffff',
-      cursorAccent: '#000000',
+      cursorAccent: '#101312',
       selectionBackground: '#4a4a4a',
       black: '#000000',
       red: '#cd3131',

--- a/packages/ui/src/components/Terminal.tsx
+++ b/packages/ui/src/components/Terminal.tsx
@@ -89,10 +89,10 @@ const getTerminalTheme = (theme: 'light' | 'dark') => {
       brightWhite: '#e5e5e5'
     },
     dark: {
-      background: '#101312',
-      foreground: '#e6ebe9',
+      background: '#000000',
+      foreground: '#ffffff',
       cursor: '#ffffff',
-      cursorAccent: '#101312',
+      cursorAccent: '#000000',
       selectionBackground: '#4a4a4a',
       black: '#000000',
       red: '#cd3131',


### PR DESCRIPTION
## Summary

A visual polish pass over the web and desktop UI: less clutter, more compact, consistent alignment, sticking to the existing monochrome palette. No behavior changes.

### Web

- Compact header (h-12) with the wordmark, a neutral connection pill, and the theme toggle; the auto-load banner is quieter and dismissible
- Terminal/Changes tab bar row removed; a segmented Terminal/Changes switch now lives inside each view's toolbar, next to the monospace worktree name and the split/fullscreen actions
- Consistent alignment rhythm: every secondary bar (view toolbars, sidebar header, diff file-list header) is h-9 with px-3 padding, so horizontal lines meet cleanly across the sidebar/content boundary
- Sidebar: compact uppercase WORKTREES header with a count, the project path moved into a tooltip, worktree items use a monospace branch name with a neutral icon
- Changes view: solid segmented Unstaged/Staged control and an uppercase file-list header aligned with the toolbars
- Improved empty states and a contained welcome card on the project screen

### Desktop

- Same token cleanups; destructive actions are now red instead of monochrome
- Terminal container uses the background token so light/dark themes stay consistent

### Explicitly unchanged

- The original monochrome color palette (an earlier iteration tried a green accent; it was reverted). Color is used only semantically: green connection dot, red destructive actions
- The create-worktree dialog keeps its original styling (a restyle used `bg-popover`, which the web Tailwind config does not map, so the surface rendered transparent; it was reverted)

## Test plan

- `pnpm typecheck`, `pnpm lint`, `pnpm test:run` all green (183 desktop tests plus package suites)
- Web e2e (Playwright) green, including the reload-restores-scrollback and PWA checks
- Before/after screenshots for welcome, terminal (dark and light), changes, and dialog views verified against a live server with real PTY sessions, in both themes