### PR TITLE
ci: drop the pnpm store prune step from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,6 @@ jobs:
         with:
           version: 8
 
-      - name: Clean pnpm cache
-        run: pnpm store prune
-
       # The node-gyp bundled with pnpm 8 does not recognize the Visual Studio
       # version on current windows-latest images; use an up-to-date one
       - name: Use current node-gyp (Windows)


### PR DESCRIPTION
The v0.2.0 release run failed in 30 seconds: pnpm 8 crashes with ENOENT when pruning a store that does not exist, which is always the case on fresh CI runners. The step had no effect there anyway, so it is removed.