### PR TITLE
ci: pin the Windows node-gyp override to a Node 20 compatible major

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,12 @@ jobs:
           version: 8
 
       # The node-gyp bundled with pnpm 8 does not recognize the Visual Studio
-      # version on current windows-latest images; use an up-to-date one
+      # version on current windows-latest images. Pinned to 11: node-gyp 12+
+      # requires Node 22, and this workflow builds with Node 20
       - name: Use current node-gyp (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          npm install -g node-gyp@latest
+          npm install -g node-gyp@11
           "npm_config_node_gyp=$(npm root -g)\node-gyp\bin\node-gyp.js" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install setuptools for Python (macOS)


### PR DESCRIPTION
Third release run failure, Windows only: the workflow installs node-gyp@latest for its Visual Studio detection workaround, and latest is now 13, which requires Node 22 and crashes on the workflow's Node 20 while configuring node-pty (webidl.util.markAsUncloneable is not a function). Pinned to node-gyp 11, which supports Node 20 and still recognizes current Visual Studio versions.