### PR TITLE
fix: add the package metadata the deb target requires

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -56,5 +56,8 @@
   },
   "appImage": {
     "artifactName": "${productName}-${version}.${ext}"
+  },
+  "deb": {
+    "artifactName": "${productName}-${version}-${arch}.${ext}"
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,6 +2,7 @@
   "name": "@vibetree/desktop",
   "version": "0.2.0",
   "description": "VibeTree Desktop Application",
+  "homepage": "https://github.com/sahithvibudhi/vibe-tree",
   "main": "dist/main/index.js",
   "scripts": {
     "predev": "cd ../../packages/core && pnpm build && cd ../../apps/desktop && pnpm copy:assets",
@@ -39,7 +40,10 @@
     "ai",
     "claude"
   ],
-  "author": "",
+  "author": {
+    "name": "Sahith Vibudhi",
+    "email": "v.sahithkumar@gmail.com"
+  },
   "license": "MIT",
   "devDependencies": {
     "@electron/rebuild": "^4.0.1",


### PR DESCRIPTION
Fourth release run got all the way to packaging: install, build, native rebuild, and the AppImage all succeeded. The deb target then failed because fpm requires a project homepage, and its filename inherited the scoped npm package name (release/@vibetree/desktop_0.2.0_amd64.deb), which the upload glob would never match.

Adds homepage and author to the desktop package.json and gives the deb an explicit artifact name. Verified locally: the deb now builds as release/VibeTree-0.2.0-amd64.deb.