### PR TITLE
ci: build Windows releases on windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,16 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # windows-2022 rather than windows-latest: the 2025 image only has
+        # Visual Studio 2026, which no node-gyp release recognizes yet, so
+        # node-pty cannot compile there
+        os: [macos-latest, ubuntu-latest, windows-2022]
         include:
           - os: macos-latest
             platform: mac
           - os: ubuntu-latest
             platform: linux
-          - os: windows-latest
+          - os: windows-2022
             platform: win
 
     runs-on: ${{ matrix.os }}
@@ -54,11 +57,11 @@ jobs:
         with:
           version: 8
 
-      # The node-gyp bundled with pnpm 8 does not recognize the Visual Studio
-      # version on current windows-latest images. Pinned to 11: node-gyp 12+
-      # requires Node 22, and this workflow builds with Node 20
+      # The node-gyp bundled with pnpm 8 does not recognize Visual Studio
+      # 2022. Pinned to 11: node-gyp 12+ requires Node 22, and this
+      # workflow builds with Node 20
       - name: Use current node-gyp (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.platform == 'win'
         run: |
           npm install -g node-gyp@11
           "npm_config_node_gyp=$(npm root -g)\node-gyp\bin\node-gyp.js" | Out-File -FilePath $env:GITHUB_ENV -Append


### PR DESCRIPTION
Fifth release run failure, Windows only: windows-latest now points at the windows-2025 image, which only ships Visual Studio 2026 (v18). No node-gyp release recognizes it yet (find-visualstudio reports unknown version at Microsoft Visual Studio\18\Enterprise), so node-pty cannot compile. Pins the Windows build to windows-2022, which still carries Visual Studio 2022.