### PR TITLE
ci: harden the release pipeline after the monorepo move

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   build:
     strategy:
+      # Every platform runs to completion so one failure cannot hide the
+      # others' results
+      fail-fast: false
       matrix:
         # windows-2022 rather than windows-latest: the 2025 image only has
         # Visual Studio 2026, which no node-gyp release recognizes yet, so
@@ -88,18 +91,22 @@ jobs:
         run: pnpm package:desktop
         timeout-minutes: 20
 
+      # Output lands in apps/desktop/release since the monorepo move; an
+      # empty upload must fail loudly instead of shipping an assetless
+      # release
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-executables
+          if-no-files-found: error
           path: |
-            release/*.dmg
-            release/*.AppImage
-            release/*.exe
-            release/*.deb
-            release/*.rpm
-            release/*.zip
-            release/*.tar.gz
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.exe
+            apps/desktop/release/*.deb
+            apps/desktop/release/*.rpm
+            apps/desktop/release/*.zip
+            apps/desktop/release/*.tar.gz
 
   release:
     needs: build
@@ -114,12 +121,13 @@ jobs:
         uses: actions/download-artifact@v4
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             mac-executables/*
             linux-executables/*
             win-executables/*
+          fail_on_unmatched_files: true
           tag_name: ${{ inputs.tag || github.ref_name }}
           target_commitish: ${{ github.sha }}
           body: ${{ inputs.notes }}

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -6,6 +6,7 @@
   },
   "files": ["dist/**/*", "package.json", "assets/icons/**/*"],
   "publish": null,
+  "npmRebuild": false,
   "mac": {
     "category": "public.app-category.developer-tools",
     "hardenedRuntime": true,


### PR DESCRIPTION
Root cause of the failure streak: the release workflow last ran in July 2025, when the app lived at the repo root. The monorepo restructure moved it to apps/desktop and the workflow was never exercised again, so each run has been peeling one layer of a year of drift, one platform at a time, because fail-fast cancelled the rest.

This closes out a full audit of every remaining step in one pass:

- electron-builder no longer runs its own native rebuild, which crashes on Windows by executing pnpm.cjs as a Win32 binary (the attempt six failure). The workflow's explicit @electron/rebuild step already rebuilds for Electron on all three platforms and is proven green everywhere.
- Artifact uploads point at apps/desktop/release, where output has landed since the monorepo move. Until now the globs matched nothing and only warned, so even a green run would have published a release with zero installers. An empty upload is now a hard failure.
- fail-fast is off, so one platform's failure can never again hide the others' results.
- The release step moves from action-gh-release v1 (node16 era) to v2 with fail_on_unmatched_files, so a missing installer can never silently publish.

Verified locally: full Linux packaging (AppImage and deb) runs end to end with the final config. Windows is proven through install, build, and rebuild by attempt six; mac through rebuild by attempt five and through full packaging by the v0.0.1 history plus no config changes on that path.