### PR TITLE
test: force-kill wedged Electron apps in e2e teardown

### DIFF
--- a/apps/desktop/e2e/helpers/test-launcher.ts
+++ b/apps/desktop/e2e/helpers/test-launcher.ts
@@ -56,10 +56,24 @@ export async function closeElectronApp(electronApp: ElectronApplication | null):
     // evaluate might throw if app already closed - that's fine
   }
 
-  try {
-    // Wait for the app to close
-    await electronApp.close();
-  } catch {
-    // Already closed - that's fine
+  // A wedged shutdown (a PTY that will not die, a cleanup hook that never
+  // resolves) must not hang the Playwright worker teardown for its full
+  // 120s budget; force-kill after a grace period instead
+  const closed = electronApp.close().then(
+    () => true,
+    () => true
+  );
+  const graceMs = 15000;
+  const finishedInTime = await Promise.race([
+    closed,
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), graceMs))
+  ]);
+  if (!finishedInTime) {
+    try {
+      electronApp.process().kill('SIGKILL');
+    } catch {
+      // Already gone - that's fine
+    }
+    await closed;
   }
 }

--- a/apps/desktop/e2e/worktree-scheduler-indicator.spec.ts
+++ b/apps/desktop/e2e/worktree-scheduler-indicator.spec.ts
@@ -231,11 +231,17 @@ test.describe('Worktree Scheduler Indicator Test', () => {
     const createButton = page.locator('button', { hasText: 'Create Branch' });
     await createButton.click();
 
+    // The dialog closes when the worktree add completes; git can be slow
+    // on loaded CI runners
+    await expect(page.locator('text=Create New Feature Branch')).not.toBeVisible({
+      timeout: 30000
+    });
+
     // Verify we now have two worktrees
     const mainWorktree = page.locator('button[data-worktree-branch="main"]');
     const testWorktree = page.locator('button[data-worktree-branch="test-branch"]');
-    await expect(mainWorktree).toBeVisible({ timeout: 10000 });
-    await expect(testWorktree).toBeVisible({ timeout: 10000 });
+    await expect(mainWorktree).toBeVisible({ timeout: 15000 });
+    await expect(testWorktree).toBeVisible({ timeout: 15000 });
 
     // Click on main worktree to select it
     await mainWorktree.click();


### PR DESCRIPTION
The latest CI failure on main was not a failing test: 45 tests passed and the one miss passed on its retry. The job failed because the first attempt's worker hung for the full 120 second teardown budget waiting for the Electron app to close, and Playwright counts a worker teardown timeout as an error even when every test ends up passing.

Two changes:

- closeElectronApp races app close against a 15 second grace period and force-kills the process if it is wedged, so a stuck shutdown can never eat a worker's teardown budget again
- the scheduler indicator spec waits for the create dialog to close (the signal that git worktree add finished) before asserting the new worktree appears, with wider timeouts, since git can be slow on loaded CI runners

Both affected specs pass locally under xvfb (5 tests, including the deliberately injected termination failure spec).