### PR TITLE
fix: drop github-pages environment claim from site deploy job

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -21,9 +21,11 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # No environment declaration on purpose. Enabling Pages in branch mode
+    # creates a github-pages environment restricted to gh-pages, which
+    # rejects any job from main that claims that environment before a
+    # single step runs. deploy-pages only needs the pages and id-token
+    # permissions granted above.
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,7 +64,6 @@ jobs:
 
       - name: Deploy
         if: steps.probe.outputs.mode == 'artifact'
-        id: deployment
         uses: actions/deploy-pages@v4
 
       - name: Publish to gh-pages branch


### PR DESCRIPTION
## Summary

Pages is now live at https://sahithvibudhi.github.io/vibe-tree/ (the managed pages-build-deployment run succeeded from gh-pages). But enabling Pages in branch mode also created a github-pages environment protection rule restricted to gh-pages, and our deploy job declares `environment: github-pages` while running from main. GitHub now rejects the job before a single step runs, so every future site update would fail.

This removes the environment declaration from the job. It was never required: the branch publish path is plain git, and actions/deploy-pages only needs the `pages: write` and `id-token: write` permissions the workflow already grants.

## Test plan

- Dispatch Deploy Site and Docs on main after merge and confirm the run goes green end to end (probe reports status 200, publishes to gh-pages)
- Confirm the managed pages build picks up the new gh-pages commit